### PR TITLE
tst_misc.sh: Fix hang in make check

### DIFF
--- a/nc_test4/tst_misc.sh
+++ b/nc_test4/tst_misc.sh
@@ -16,7 +16,7 @@ echo "*** Fail: phony dimension creation"
 ECODE=1
 fi
 
-if "x$NC_VLEN_NOTEST" = x1 ; then
+if test "x$NC_VLEN_NOTEST" = x1 ; then
 echo "*** Testing char(*) type printout error in ncdump"
 rm -f ./tst_charvlenbug.nc ./tmp
 ${execdir}/tst_charvlenbug


### PR DESCRIPTION
Fix mistake in tst_misc.sh that results in hang in make check, during nc_test4 phase.

Affects netcdf-c 4.8.1 on Mac OS.